### PR TITLE
Add XunitLogger implementation and tests

### DIFF
--- a/Logging/LoggingBuilderExtensions.cs
+++ b/Logging/LoggingBuilderExtensions.cs
@@ -6,10 +6,20 @@ namespace xUnit.OTel.Extensions;
 
 public static class LoggingBuilderExtensions
 {
-    public static ILoggingBuilder AddXUnitOutput(this ILoggingBuilder builder)
+    public static ILoggingBuilder AddXUnitOutput(
+        this ILoggingBuilder builder,
+        Action<XunitLoggerOptions>? configure = null)
     {
-        builder.Services.TryAddSingleton<ILoggerProvider>(provider => new XunitLoggerProvider(
-            ));
+        builder.Services.TryAddSingleton<ITestOutputHelperAccessor, TestOutputHelperAccessor>();
+
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(sp =>
+        {
+            var accessor = sp.GetRequiredService<ITestOutputHelperAccessor>();
+            var options = new XunitLoggerOptions();
+            configure?.Invoke(options);
+            return new XunitLoggerProvider(accessor, options);
+        }));
+
         return builder;
     }
 

--- a/Logging/XunitLogger.cs
+++ b/Logging/XunitLogger.cs
@@ -1,0 +1,87 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace xUnit.OTel.Logging;
+
+public class XunitLogger : ILogger
+{
+    private readonly string _categoryName;
+    private readonly ITestOutputHelperAccessor _outputHelperAccessor;
+    private readonly XunitLoggerOptions _options;
+    private readonly IExternalScopeProvider _scopeProvider;
+
+    public XunitLogger(
+        string categoryName,
+        ITestOutputHelperAccessor outputHelperAccessor,
+        XunitLoggerOptions options,
+        IExternalScopeProvider scopeProvider)
+    {
+        _categoryName = categoryName ?? throw new ArgumentNullException(nameof(categoryName));
+        _outputHelperAccessor = outputHelperAccessor ?? throw new ArgumentNullException(nameof(outputHelperAccessor));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _scopeProvider = scopeProvider ?? throw new ArgumentNullException(nameof(scopeProvider));
+    }
+
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        return _scopeProvider.Push(state)!;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return logLevel != LogLevel.None && _options.Filter(_categoryName, logLevel);
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        if (formatter is null)
+        {
+            throw new ArgumentNullException(nameof(formatter));
+        }
+
+        var outputHelper = _outputHelperAccessor.Output;
+        if (outputHelper is null)
+        {
+            return;
+        }
+
+        var message = formatter(state, exception);
+        if (string.IsNullOrEmpty(message) && exception == null)
+        {
+            return;
+        }
+
+        var builder = new StringBuilder();
+
+        if (!string.IsNullOrEmpty(_options.TimestampFormat))
+        {
+            var timestamp = _options.TimeProvider.GetLocalNow().ToString(_options.TimestampFormat, CultureInfo.InvariantCulture);
+            builder.Append(timestamp).Append(' ');
+        }
+
+        builder.Append('[').Append(logLevel.ToString()).Append("] ");
+        builder.Append(_categoryName).Append(": ").Append(message);
+
+        if (exception != null)
+        {
+            builder.Append(' ').Append(exception);
+        }
+
+        if (_options.IncludeScopes)
+        {
+            _scopeProvider.ForEachScope((scope, state) =>
+            {
+                state.Append(" => ").Append(scope);
+            }, builder);
+        }
+
+        outputHelper.WriteLine(builder.ToString());
+    }
+}

--- a/tests/xUnit.OTel.Tests/Logging/XunitLoggerTests.cs
+++ b/tests/xUnit.OTel.Tests/Logging/XunitLoggerTests.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using xUnit.OTel.Logging;
+
+namespace xUnit.OTel.Tests.Logging;
+
+public class FakeTestOutputHelper : ITestOutputHelper
+{
+    public List<string> Lines { get; } = new();
+
+    public void WriteLine(string message)
+    {
+        Lines.Add(message);
+    }
+
+    public void WriteLine(string format, params object[] args)
+    {
+        Lines.Add(string.Format(format, args));
+    }
+}
+
+public class FakeAccessor : ITestOutputHelperAccessor
+{
+    public FakeAccessor(ITestOutputHelper helper) => Output = helper;
+    public ITestOutputHelper? Output { get; }
+}
+
+public class XunitLoggerTests
+{
+    [Fact]
+    public void Log_Writes_Message_To_Output()
+    {
+        var helper = new FakeTestOutputHelper();
+        var accessor = new FakeAccessor(helper);
+        var logger = new XunitLogger("Test", accessor, new XunitLoggerOptions());
+
+        logger.LogInformation("Hello");
+
+        Assert.Single(helper.Lines);
+        Assert.Contains("Hello", helper.Lines[0]);
+    }
+}

--- a/tests/xUnit.OTel.Tests/xUnit.OTel.Tests.csproj
+++ b/tests/xUnit.OTel.Tests/xUnit.OTel.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../xUnit.OTel.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
+  </ItemGroup>
+</Project>

--- a/xUnit.OTel.sln
+++ b/xUnit.OTel.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xUnit.OTel.Tests", "tests\xUnit.OTel.Tests\xUnit.OTel.Tests.csproj", "{DEADBEEF-0000-0000-0000-000000000001}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
## Summary
- implement `XunitLogger` and provider with scope support
- add logging builder extension to register provider
- create basic xUnit tests project for logger

## Testing
- `dotnet test xUnit.OTel.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688947f497f8832b921aa5142af53e7d