### PR TITLE
Fix publish workflow and package readme path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,9 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
         echo "Extracted version: $VERSION"
 
-    - name: Update project version
-      run: |
-        sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.get_version.outputs.VERSION }}<\/Version>/" xUnit.OTel.csproj
+      - name: Update project version
+        run: |
+          sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.get_version.outputs.VERSION }}<\/Version>/" src/xUnit.OTel/xUnit.OTel.csproj
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,16 +18,16 @@ jobs:
       with:
         dotnet-version: '8.0.x'
 
-      - name: Extract version from tag
-        id: get_version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "Extracted version: $VERSION"
+    - name: Extract version from tag
+      id: get_version
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/v}
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+        echo "Extracted version: $VERSION"
 
-      - name: Update project version
-        run: |
-          sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.get_version.outputs.VERSION }}<\/Version>/" src/xUnit.OTel/xUnit.OTel.csproj
+    - name: Update project version
+      run: |
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.get_version.outputs.VERSION }}<\/Version>/" src/xUnit.OTel/xUnit.OTel.csproj
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,12 @@ jobs:
       with:
         dotnet-version: '8.0.x'
 
-    - name: Extract version from tag
-      id: get_version
-      run: |
-        VERSION=${GITHUB_REF#refs/tags/v}
-        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-        echo "Extracted version: $VERSION"
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
 
       - name: Update project version
         run: |

--- a/src/xUnit.OTel/xUnit.OTel.csproj
+++ b/src/xUnit.OTel/xUnit.OTel.csproj
@@ -16,7 +16,7 @@
     <RepositoryUrl>https://github.com/mrviduus/xUnit.OTel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>..\..\README.md</PackageReadmeFile>
+    <PackageReadmeFile>../../README.md</PackageReadmeFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -25,6 +25,10 @@
     <Compile Remove="xUnit.OTel.Tests\**" />
     <EmbeddedResource Remove="xUnit.OTel.Tests\**" />
     <None Remove="xUnit.OTel.Tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 

--- a/src/xUnit.OTel/xUnit.OTel.csproj
+++ b/src/xUnit.OTel/xUnit.OTel.csproj
@@ -16,7 +16,8 @@
     <RepositoryUrl>https://github.com/mrviduus/xUnit.OTel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>../../README.md</PackageReadmeFile>
+    <!-- README is located in the repository root. Include it in the package -->
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -28,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Include the root README in the package at the package root -->
     <None Include="../../README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 

--- a/src/xUnit.OTel/xUnit.OTel.csproj
+++ b/src/xUnit.OTel/xUnit.OTel.csproj
@@ -16,7 +16,7 @@
     <RepositoryUrl>https://github.com/mrviduus/xUnit.OTel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>..\..\README.md</PackageReadmeFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -27,9 +27,6 @@
     <None Remove="xUnit.OTel.Tests\**" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" />


### PR DESCRIPTION
## Summary
- fix path to README file in csproj for NuGet packaging
- correct project path in publish workflow

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688982873304832b89510bb620bbc58f