### PR TITLE
refactor: professional README rewrite, centralize tag constants

### DIFF
--- a/src/xUnitOTel/Attributes/TraceAttribute.cs
+++ b/src/xUnitOTel/Attributes/TraceAttribute.cs
@@ -1,93 +1,52 @@
-// Import System.Diagnostics for Activity and ActivityKind classes
 using System.Diagnostics;
-// Import System.Reflection for MethodInfo class
 using System.Reflection;
-// Import custom diagnostics functionality for OpenTelemetry integration
 using xUnitOTel.Diagnostics;
-// Import xUnit internal functionality for console capture
 using Xunit.Internal;
-// Import xUnit v3 framework interfaces and classes
 using Xunit.v3;
 
-// Define the namespace for xUnit OpenTelemetry attributes
 namespace xUnitOTel.Attributes;
-// Define a custom attribute that extends BeforeAfterTestAttribute to add tracing capabilities
+
+/// <summary>
+/// xUnit attribute that wraps test methods in OpenTelemetry spans for distributed tracing.
+/// Can be applied at assembly level [assembly: Trace] or per-test method.
+/// </summary>
 public class TraceAttribute : BeforeAfterTestAttribute
 {
-    // Constant string for the OpenTelemetry tag that identifies the test class and method
-    private const string TestClassMethodTag = "test.class.method";
-    // Constant string for the OpenTelemetry tag that identifies the test name
-    private const string TestNameTag = "test.name";
-    // Constant string for the OpenTelemetry tag that identifies the testing framework
-    private const string TestFrameworkTag = "test.framework";
-    // Constant string value identifying this as an xUnit test framework
-    private const string TestFrameworkName = "xunit";
 
-    // Lazy initialization of console capture writer to ensure thread-safe single instance creation
-    // This captures both error and standard output streams for test execution
     private static readonly Lazy<ConsoleCaptureTestOutputWriter> ConsoleCaptureWriter = new(() =>
-        // Create a new console capture writer that captures both error and standard output
         new ConsoleCaptureTestOutputWriter(TestContextAccessor.Instance, captureError: true, captureOut: true),
-        // Ensure thread-safe lazy initialization with publication semantics
         LazyThreadSafetyMode.ExecutionAndPublication);
 
-    // Private field to store the current OpenTelemetry Activity instance for this test execution
     private Activity? _activity;
 
-    // Public property to control whether error output should be captured (defaults to true)
     public bool CaptureError { get; set; } = true;
-    // Public property to control whether standard output should be captured (defaults to true)
     public bool CaptureOut { get; set; } = true;
 
-    // Override method that executes before each test method runs
     public override void Before(MethodInfo methodUnderTest, IXunitTest test)
     {
-        // Initialize console capturing lazily and safely by accessing the Value property
-        // The underscore assignment discards the return value as we only need initialization
         _ = ConsoleCaptureWriter.Value;
 
-        // Create a descriptive activity name using the full class name and method name
-        // If the declaring type is null, fall back to just the method name
         var activityName = methodUnderTest.DeclaringType != null
             ? $"{methodUnderTest.DeclaringType.FullName}.{methodUnderTest.Name}"
             : methodUnderTest.Name;
 
-        // Start a new OpenTelemetry Activity with the constructed name and Internal kind
-        // This creates a new span in the distributed trace for this test execution
         _activity = ApplicationDiagnostics.ActivitySource.StartActivity(activityName, ActivityKind.Internal);
 
-        // Check if the activity was successfully created (could be null if no listeners)
         if (_activity is not null)
         {
-            // Set OpenTelemetry tags on the activity to provide metadata about the test
-            // Tag for the full test class and method identification
-            _activity.SetTag(TestClassMethodTag, activityName);
-            // Tag for just the test method name
-            _activity.SetTag(TestNameTag, methodUnderTest.Name);
-            // Tag to identify this trace as coming from the xUnit framework
-            _activity.SetTag(TestFrameworkTag, TestFrameworkName);
+            _activity.SetTag(OpenTelemetryTagNames.TestClassMethod, activityName);
+            _activity.SetTag(OpenTelemetryTagNames.TestName, methodUnderTest.Name);
+            _activity.SetTag(OpenTelemetryTagNames.TestFramework, OpenTelemetryTagNames.TestFrameworkXUnit);
         }
     }
 
-    // Override method that executes after each test method completes
     public override void After(MethodInfo methodUnderTest, IXunitTest test)
     {
-        // Stop the activity if it exists, marking the end of the test execution span
-        _activity?.Stop();
-        // Check if we have a valid activity instance to work with
-        if (_activity != null)
-        {
-            // Extract the trace ID from the activity and convert it to a string
-            // This provides a unique identifier for the entire distributed trace
-            var traceId = _activity.TraceId.ToString();
+        if (_activity is null) return;
 
-            // Output the trace ID to the test output for debugging and correlation purposes
-            // This allows developers to correlate test results with distributed traces
-            TestContextAccessor.Instance.Current?.TestOutputHelper?.WriteLine($"Trace ID: {traceId}");
-
-
-            // Dispose of the activity to free up resources and complete the span
-            _activity.Dispose();
-        }
+        _activity.Stop();
+        var traceId = _activity.TraceId.ToString();
+        TestContextAccessor.Instance.Current?.TestOutputHelper?.WriteLine($"Trace ID: {traceId}");
+        _activity.Dispose();
     }
 }

--- a/src/xUnitOTel/OpenTelemetryTagNames.cs
+++ b/src/xUnitOTel/OpenTelemetryTagNames.cs
@@ -1,0 +1,13 @@
+namespace xUnitOTel;
+
+/// <summary>
+/// Centralized OpenTelemetry tag name constants for test instrumentation.
+/// </summary>
+public static class OpenTelemetryTagNames
+{
+    public const string TestClassMethod = "test.class.method";
+    public const string TestName = "test.name";
+    public const string TestFramework = "test.framework";
+    public const string TestRunId = "testrun.id";
+    public const string TestFrameworkXUnit = "xunit";
+}

--- a/src/xUnitOTel/Processors/TestRunIdProcessor.cs
+++ b/src/xUnitOTel/Processors/TestRunIdProcessor.cs
@@ -1,28 +1,18 @@
-// Import System.Diagnostics for Activity class functionality
 using System.Diagnostics;
-// Import OpenTelemetry core functionality for processors
 using OpenTelemetry;
 
-// Define the namespace for OpenTelemetry processors
 namespace xUnitOTel.Processors;
 
-// Processor class that adds a unique test run identifier to all activities
-// This processor extends BaseProcessor<Activity> to automatically tag activities with test run information
-// The test run ID helps correlate all activities from a single test execution session
-public class TestRunIdProcessor: BaseProcessor<Activity>
+/// <summary>
+/// Processor that adds a unique test run identifier to all activities.
+/// Enables correlation of all spans from a single test execution session.
+/// </summary>
+public class TestRunIdProcessor : BaseProcessor<Activity>
 {
-    // Static readonly GUID that uniquely identifies this test run session
-    // This ID is generated once when the class is first loaded and remains constant for the entire test run
-    // It allows grouping and filtering activities by test run in telemetry backends
     private static readonly Guid TestRunId = Guid.NewGuid();
 
-    // Override method that is called when an activity is started
-    // This method automatically adds the test run ID as a tag to every activity
     public override void OnStart(Activity data)
     {
-        // Add a tag with the test run ID to the activity
-        // This tag will be included in all telemetry data and can be used for filtering and correlation
-        // The "testrun.id" tag follows OpenTelemetry semantic conventions for test-related metadata
-        data.SetTag("testrun.id", TestRunId.ToString());
+        data.SetTag(OpenTelemetryTagNames.TestRunId, TestRunId.ToString());
     }
 }


### PR DESCRIPTION
## Summary
- Full README.md rewrite: professional tone, Mermaid diagram, config tables, troubleshooting section
- New `OpenTelemetryTagNames.cs` for centralized tag constants
- `TraceAttribute`: use constants, fix redundant null check pattern
- `TestRunIdProcessor`: use constants, remove verbose comments

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet run` tests pass (1/1)
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)